### PR TITLE
Wrong parameter name for config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install mongo-seeding --save
         port: 27017,
         name: 'mydatabase',
       },
-      dataPath: path.resolve(__dirname, '../data'),
+      inputPath: path.resolve(__dirname, '../data'),
       dropDatabase: true,
     };
     ```


### PR DESCRIPTION
Hi, 

I think the example in the doc should be `inputPath` as in `config.js`.

Now it is `datapath` in the doc.
