### PR TITLE
Enable Parameter Parsing with Mongo 3.6 Cluster Connection Protocol

### DIFF
--- a/core/src/database/database-connector.ts
+++ b/core/src/database/database-connector.ts
@@ -101,6 +101,10 @@ export class DatabaseConnector {
     if (username) {
       credentials = `${username}${password ? `:${password}` : ''}@`;
     }
+
+    if (protocol === 'mongodb+srv') {
+        return `${protocol}://${credentials}${host}/${name}`;    
+    }
     return `${protocol}://${credentials}${host}:${port}/${name}`;
   }
 

--- a/core/test/unit/DatabaseConnector.ts
+++ b/core/test/unit/DatabaseConnector.ts
@@ -29,6 +29,13 @@ const dbConfig: SeederDatabaseConfig = {
   name: 'database',
 };
 
+const dbConfigv3_6: SeederDatabaseConfig = {
+  protocol: 'mongodb+srv',
+  host: '127.0.0.1',
+  port: 27017,
+  name: 'database',
+};
+
 describe('DatabaseConnector', () => {
   it('should throw error when trying connecting without config', async () => {
     // @ts-ignore
@@ -40,6 +47,12 @@ describe('DatabaseConnector', () => {
     const uri = databaseConnector.getDbConnectionUri(dbConfig);
     expect(uri).toBe(expectedUri);
   });
+
+  it('should return valid DB connection URI with Mongo 3.6 protocol', () => {
+      const expectedUri = 'mongodb+srv://127.0.0.1/database';
+      const uri = databaseConnector.getDbConnectionUri(dbConfigv3_6);
+      expect(uri).toBe(expectedUri);
+  })
 
   it('should return valid DB connection URI with username only', () => {
     const authConfig: SeederDatabaseConfig = {

--- a/core/test/unit/DatabaseConnector.ts
+++ b/core/test/unit/DatabaseConnector.ts
@@ -29,13 +29,6 @@ const dbConfig: SeederDatabaseConfig = {
   name: 'database',
 };
 
-const dbConfigv3_6: SeederDatabaseConfig = {
-  protocol: 'mongodb+srv',
-  host: '127.0.0.1',
-  port: 27017,
-  name: 'database',
-};
-
 describe('DatabaseConnector', () => {
   it('should throw error when trying connecting without config', async () => {
     // @ts-ignore
@@ -49,10 +42,16 @@ describe('DatabaseConnector', () => {
   });
 
   it('should return valid DB connection URI with Mongo 3.6 protocol', () => {
-      const expectedUri = 'mongodb+srv://127.0.0.1/database';
-      const uri = databaseConnector.getDbConnectionUri(dbConfigv3_6);
-      expect(uri).toBe(expectedUri);
-  })
+    const dbConfig: SeederDatabaseConfig = {
+      protocol: 'mongodb+srv',
+      host: '127.0.0.1',
+      port: 27017,
+      name: 'database',
+    };
+    const expectedUri = 'mongodb+srv://127.0.0.1/database';
+    const uri = databaseConnector.getDbConnectionUri(dbConfig);
+    expect(uri).toBe(expectedUri);
+  });
 
   it('should return valid DB connection URI with username only', () => {
     const authConfig: SeederDatabaseConfig = {


### PR DESCRIPTION
[See this issue](https://github.com/pkosiec/mongo-seeding/issues/63). This PR makes parameter parsing for config values check the protocol. If the protocol is Mongo 3.6's new cluster connection protocol (`mongodb+srv`), create the associated connection string (essentially just dropping the port.)

Resolves #63 