### PR TITLE
Include missing MongoDB driver types in production build 

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
+        "@types/mongodb": "^3.6.20",
         "bson": "^4.5.3",
         "debug": "^4.3.1",
         "extend": "^3.0.0",
@@ -18,7 +19,6 @@
       "devDependencies": {
         "@types/extend": "^3.0.1",
         "@types/jest": "^27.0.2",
-        "@types/mongodb": "^3.6.20",
         "jest": "^27.2.5",
         "ts-jest": "^27.0.6",
         "typescript": "^4.4.4"
@@ -1354,7 +1354,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
       "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1412,7 +1411,6 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
       "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dev": true,
       "dependencies": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -1421,8 +1419,7 @@
     "node_modules/@types/node": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
-      "dev": true
+      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw=="
     },
     "node_modules/@types/prettier": {
       "version": "2.4.1",
@@ -6869,7 +6866,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
       "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -6927,7 +6923,6 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
       "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dev": true,
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -6936,8 +6931,7 @@
     "@types/node": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.6.1.tgz",
-      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==",
-      "dev": true
+      "integrity": "sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw=="
     },
     "@types/prettier": {
       "version": "2.4.1",

--- a/core/package.json
+++ b/core/package.json
@@ -54,12 +54,12 @@
     "debug": "^4.3.1",
     "extend": "^3.0.0",
     "import-fresh": "^3.3.0",
-    "mongodb": "^3.6.4"
+    "mongodb": "^3.6.4",
+    "@types/mongodb": "^3.6.20"
   },
   "devDependencies": {
     "@types/extend": "^3.0.1",
     "@types/jest": "^27.0.2",
-    "@types/mongodb": "^3.6.20",
     "jest": "^27.2.5",
     "ts-jest": "^27.0.6",
     "typescript": "^4.4.4"


### PR DESCRIPTION
As Mongo Seeding TS types depends on MongoDB driver v3 ones (from `@types/mongodb`), they should be included in the production build to avoid compilation errors when using Mongo Seeding with MongoDB v4 driver. See the discussion in #182.

## Related issues
Resolves #182 