### PR TITLE
Remove `linux/arm/v7` from multi-arch Docker image

### DIFF
--- a/scripts/publish-npm-and-docker.sh
+++ b/scripts/publish-npm-and-docker.sh
@@ -24,7 +24,7 @@ echo "Using tag: ${IMAGE_VERSION_TAG}"
 docker buildx create --name mongo-seeding-bldr --bootstrap --use
 
 docker buildx build --push \
-  --platform linux/amd64,linux/arm64,linux/arm/v7 \
+  --platform linux/amd64,linux/arm64 \
   --builder mongo-seeding-bldr \
   --tag ${IMAGE_NAME}:${IMAGE_VERSION_TAG} \
   --build-arg cliVersion=${IMAGE_VERSION_TAG} \


### PR DESCRIPTION
This is caused by this bug: https://github.com/nodejs/node/issues/50847
Until it is resolved, the Mongo Seeding multi-arch image won't be built `armv7`platform, unfortunately.